### PR TITLE
Global hotkey support

### DIFF
--- a/emojione-picker
+++ b/emojione-picker
@@ -3,6 +3,7 @@
 #
 
 import os
+import socket
 import sys
 import json
 from os.path import expanduser
@@ -42,7 +43,15 @@ default_settings = settings = {
 configpath = expanduser("~") + "/.config/emojione-picker"
 os.path.isdir(configpath) or os.mkdir(configpath)
 
+sockname = '/tmp/emojisocket.' + str(os.getuid()) + os.environ['DISPLAY']
+
 builder = Gtk.Builder()
+
+def handle_sock_signal(sock, *args):
+    GLib.io_add_watch(sock, GLib.IO_IN, handle_sock_signal)
+    conn, addr = sock.accept()
+    conn.close()
+    open_search_window('','')
 
 def exit(self, w):
     sys.exit()
@@ -290,215 +299,231 @@ def get_emoji_group(code):
     return False
 
 if __name__ == "__main__":
-    # Calling GObject.threads_init() is not needed for PyGObject 3.10.2+
-    GObject.threads_init()
-
-    # Initialize notifications
-    Notify.init("emojione-picker")
-
-    # Create the main menu
-    menu = Gtk.Menu()
-
-    # Create indicator
-    ind = appindicator.Indicator.new("emojione-picker", directory + "/assets/icon-default.svg", appindicator.IndicatorCategory.APPLICATION_STATUS)
-    ind.set_status(appindicator.IndicatorStatus.ACTIVE)
-
-    # If there is a icon present in the theme, use it!
     try:
-      icons = Gtk.IconTheme.get_default()
-      icon = icons.load_icon("emojione-picker", Gtk.IconSize.MENU, 0)
-      ind.set_icon("emojione-picker")
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(sockname)
     except:
-      pass
+        # Calling GObject.threads_init() is not needed for PyGObject 3.10.2+
+        GObject.threads_init()
 
-    # Get proper icon sizes
-    iconsizes = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
-    
-    # Create categories items and submenus
-    category_item = {}
-    category_menu = {}
-    for category in categories:
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/categories/" + category + ".svg", iconsizes[1], iconsizes[2])
-        img = Gtk.Image.new_from_pixbuf(pixbuf)
-        category_item[category] = Gtk.ImageMenuItem(category.title())
-        item_settings = category_item[category].get_settings()
-        item_settings.set_property('gtk-menu-images', True)
-        GLib.idle_add(category_item[category].set_image, img)
-        category_menu[category] = Gtk.Menu()
-        category_item[category].set_submenu(category_menu[category]);
+        # Initialize notifications
+        Notify.init("emojione-picker")
 
-    # Load groups and icons definition and rearrange them in order
-    with open(directory + "/assets/groups.json") as groups_file:
-        groups_data = json.load(groups_file)
-    with open(directory + "/assets/emoji.json") as json_file:
-        json_data = json.load(json_file)
-        def orderfunc(tup):
-            key, d = tup
-            return int(d["emoji_order"])
-        sorted_data = sorted(json_data.items(), key=orderfunc)
-        sorted_data = OrderedDict(sorted_data)
+        # Create the main menu
+        menu = Gtk.Menu()
 
-    # Load icons into menu items
-    tones_re = re.compile('(.*) tone[ ]?\d', re.IGNORECASE)
-    item_groups = {}
-    submenu_groups = {}
-    items = {}
-    tone_groups = {}
-    submenu_tones = {}
-    signals = {}
-    for category in categories:
-        for key in sorted_data:
-            if settings["lowend"] == False or not sorted_data[key]["unicode"] in lowend:
-                if sorted_data[key]["category"] == category:
-                    emoji_group = get_emoji_group(sorted_data[key]["unicode"])
-                    if emoji_group != False:
-                        # Grouped emoji
-                        if not emoji_group in item_groups:
-                            # Create group item
-                            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + groups_data[emoji_group]["icon"] + ".svg", iconsizes[1], iconsizes[2])
-                            img = Gtk.Image.new_from_pixbuf(pixbuf)
-                            item_groups[emoji_group] = Gtk.ImageMenuItem(groups_data[emoji_group]["name"].title())
-                            item_settings = item_groups[emoji_group].get_settings()
-                            item_settings.set_property('gtk-menu-images', True)
-                            GLib.idle_add(item_groups[emoji_group].set_image, img)
-                            GLib.idle_add(category_menu[category].append, item_groups[emoji_group])
-                            GLib.idle_add(item_groups[emoji_group].show)
-                            # Create group submenu
-                            submenu_groups[emoji_group] = Gtk.Menu()
-                            GLib.idle_add(item_groups[emoji_group].set_submenu, submenu_groups[emoji_group])
-                        if tones_re.match(sorted_data[key]["name"]) == None:
-                            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
-                            img = Gtk.Image.new_from_pixbuf(pixbuf)
-                            items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
-                            item_settings = items[sorted_data[key]["unicode"]].get_settings()
-                            item_settings.set_property('gtk-menu-images', True)
-                            GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
-                            GLib.idle_add(submenu_groups[emoji_group].append, items[sorted_data[key]["unicode"]])
-                            GLib.idle_add(items[sorted_data[key]["unicode"]].show)
-                            signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
-                        else:
-                            # This won't happen, we are not grouping toned icons
-                            pass
-                    else:
-                        if tones_re.match(sorted_data[key]["name"]) == None: 
-                            # Not toned emoji (aka simplest case), just add to menu
-                            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
-                            img = Gtk.Image.new_from_pixbuf(pixbuf)
-                            items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
-                            item_settings = items[sorted_data[key]["unicode"]].get_settings()
-                            item_settings.set_property('gtk-menu-images', True)
-                            GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
-                            GLib.idle_add(category_menu[category].append, items[sorted_data[key]["unicode"]])
-                            GLib.idle_add(items[sorted_data[key]["unicode"]].show)
-                            signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
-                        else:
-                            # Toned emoji
-                            if settings["toned"] == -1 and settings["lowend"] == False:
-                                # Show all toned emojis in a submenu
-                                original_key = key
-                                chars = sorted_data[key]["unicode"].split("-")
-                                tone_group = chars[0] # FIXME this can be multibyte so taking the first byt isn't right
-                                if not tone_group in tone_groups:
-                                    # Create tone submenu
-                                    submenu_tones[tone_group] = Gtk.Menu()
-                                    GLib.idle_add(items[tone_group].set_submenu, submenu_tones[tone_group])
-                                    tone_groups[tone_group] = items[tone_group]
-                                    # Get key from original icon
-                                    for k in sorted_data:
-                                        if sorted_data[k]["unicode"] == tone_group:
-                                            key = k
-                                    # Append untoned icon to submenu
-                                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
-                                    img = Gtk.Image.new_from_pixbuf(pixbuf)
-                                    items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
-                                    item_settings = items[tone_group].get_settings()
-                                    item_settings.set_property('gtk-menu-images', True)
-                                    GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
-                                    GLib.idle_add(submenu_tones[tone_group].append, items[sorted_data[key]["unicode"]])
-                                    GLib.idle_add(items[sorted_data[key]["unicode"]].show)
-                                    signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
-                                key = original_key
-                                # Append toned emoji to toned submenu
+        # Create indicator
+        ind = appindicator.Indicator.new("emojione-picker", directory + "/assets/icon-default.svg", appindicator.IndicatorCategory.APPLICATION_STATUS)
+        ind.set_status(appindicator.IndicatorStatus.ACTIVE)
+
+        # If there is a icon present in the theme, use it!
+        try:
+          icons = Gtk.IconTheme.get_default()
+          icon = icons.load_icon("emojione-picker", Gtk.IconSize.MENU, 0)
+          ind.set_icon("emojione-picker")
+        except:
+          pass
+
+        # Get proper icon sizes
+        iconsizes = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
+        
+        # Create categories items and submenus
+        category_item = {}
+        category_menu = {}
+        for category in categories:
+            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/categories/" + category + ".svg", iconsizes[1], iconsizes[2])
+            img = Gtk.Image.new_from_pixbuf(pixbuf)
+            category_item[category] = Gtk.ImageMenuItem(category.title())
+            item_settings = category_item[category].get_settings()
+            item_settings.set_property('gtk-menu-images', True)
+            GLib.idle_add(category_item[category].set_image, img)
+            category_menu[category] = Gtk.Menu()
+            category_item[category].set_submenu(category_menu[category]);
+
+        # Load groups and icons definition and rearrange them in order
+        with open(directory + "/assets/groups.json") as groups_file:
+            groups_data = json.load(groups_file)
+        with open(directory + "/assets/emoji.json") as json_file:
+            json_data = json.load(json_file)
+            def orderfunc(tup):
+                key, d = tup
+                return int(d["emoji_order"])
+            sorted_data = sorted(json_data.items(), key=orderfunc)
+            sorted_data = OrderedDict(sorted_data)
+
+        # Load icons into menu items
+        tones_re = re.compile('(.*) tone[ ]?\d', re.IGNORECASE)
+        item_groups = {}
+        submenu_groups = {}
+        items = {}
+        tone_groups = {}
+        submenu_tones = {}
+        signals = {}
+        for category in categories:
+            for key in sorted_data:
+                if settings["lowend"] == False or not sorted_data[key]["unicode"] in lowend:
+                    if sorted_data[key]["category"] == category:
+                        emoji_group = get_emoji_group(sorted_data[key]["unicode"])
+                        if emoji_group != False:
+                            # Grouped emoji
+                            if not emoji_group in item_groups:
+                                # Create group item
+                                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + groups_data[emoji_group]["icon"] + ".svg", iconsizes[1], iconsizes[2])
+                                img = Gtk.Image.new_from_pixbuf(pixbuf)
+                                item_groups[emoji_group] = Gtk.ImageMenuItem(groups_data[emoji_group]["name"].title())
+                                item_settings = item_groups[emoji_group].get_settings()
+                                item_settings.set_property('gtk-menu-images', True)
+                                GLib.idle_add(item_groups[emoji_group].set_image, img)
+                                GLib.idle_add(category_menu[category].append, item_groups[emoji_group])
+                                GLib.idle_add(item_groups[emoji_group].show)
+                                # Create group submenu
+                                submenu_groups[emoji_group] = Gtk.Menu()
+                                GLib.idle_add(item_groups[emoji_group].set_submenu, submenu_groups[emoji_group])
+                            if tones_re.match(sorted_data[key]["name"]) == None:
                                 pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
                                 img = Gtk.Image.new_from_pixbuf(pixbuf)
                                 items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
                                 item_settings = items[sorted_data[key]["unicode"]].get_settings()
                                 item_settings.set_property('gtk-menu-images', True)
                                 GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
-                                GLib.idle_add(submenu_tones[tone_group].append, items[sorted_data[key]["unicode"]])
+                                GLib.idle_add(submenu_groups[emoji_group].append, items[sorted_data[key]["unicode"]])
                                 GLib.idle_add(items[sorted_data[key]["unicode"]].show)
                                 signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
                             else:
-                                # Show only one tone for toned emojis
-                                if settings["toned"] == 0 or settings["lowend"] == True:
-                                    # Untoned emojis are already shown by default, so do nothing
-                                    # When using lowend mode, untoned emojis are enforced
-                                    pass
-                                else:
-                                    desired_tone = settings["toned"]
-                                    current_tone = re.search("\d",sorted_data[key]["name"]).group(0)
-                                    if desired_tone == int(current_tone):
-                                        # Replace item with desired tone
-                                        toned_key = key
-                                        chars = sorted_data[key]["unicode"].split("-") # FIXME this can be multibyte so taking the first byt isn't right
-                                        untoned_code = chars[0]
+                                # This won't happen, we are not grouping toned icons
+                                pass
+                        else:
+                            if tones_re.match(sorted_data[key]["name"]) == None: 
+                                # Not toned emoji (aka simplest case), just add to menu
+                                pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
+                                img = Gtk.Image.new_from_pixbuf(pixbuf)
+                                items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
+                                item_settings = items[sorted_data[key]["unicode"]].get_settings()
+                                item_settings.set_property('gtk-menu-images', True)
+                                GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
+                                GLib.idle_add(category_menu[category].append, items[sorted_data[key]["unicode"]])
+                                GLib.idle_add(items[sorted_data[key]["unicode"]].show)
+                                signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
+                            else:
+                                # Toned emoji
+                                if settings["toned"] == -1 and settings["lowend"] == False:
+                                    # Show all toned emojis in a submenu
+                                    original_key = key
+                                    chars = sorted_data[key]["unicode"].split("-")
+                                    tone_group = chars[0] # FIXME this can be multibyte so taking the first byt isn't right
+                                    if not tone_group in tone_groups:
+                                        # Create tone submenu
+                                        submenu_tones[tone_group] = Gtk.Menu()
+                                        GLib.idle_add(items[tone_group].set_submenu, submenu_tones[tone_group])
+                                        tone_groups[tone_group] = items[tone_group]
+                                        # Get key from original icon
                                         for k in sorted_data:
-                                            if sorted_data[k]["unicode"] == untoned_code:
+                                            if sorted_data[k]["unicode"] == tone_group:
                                                 key = k
-                                        # Replace image in item
-                                        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[toned_key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
+                                        # Append untoned icon to submenu
+                                        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
                                         img = Gtk.Image.new_from_pixbuf(pixbuf)
+                                        items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
+                                        item_settings = items[tone_group].get_settings()
+                                        item_settings.set_property('gtk-menu-images', True)
                                         GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
-                                        # Replace action
-                                        items[sorted_data[key]["unicode"]].disconnect(signals[key])
-                                        signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[toned_key])
-                                
-    # Load icons into recent category
-    recent_items = []
-    for i in range (0, settings["recent"]):
-        recent_items.append( Gtk.ImageMenuItem())
-        item_settings = recent_items[i].get_settings()
-        item_settings.set_property('gtk-menu-images', True)
-        category_menu["recent"].append(recent_items[i])
-    refresh_recent_submenu()
+                                        GLib.idle_add(submenu_tones[tone_group].append, items[sorted_data[key]["unicode"]])
+                                        GLib.idle_add(items[sorted_data[key]["unicode"]].show)
+                                        signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
+                                    key = original_key
+                                    # Append toned emoji to toned submenu
+                                    pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
+                                    img = Gtk.Image.new_from_pixbuf(pixbuf)
+                                    items[sorted_data[key]["unicode"]] = Gtk.ImageMenuItem(sorted_data[key]["name"].title())
+                                    item_settings = items[sorted_data[key]["unicode"]].get_settings()
+                                    item_settings.set_property('gtk-menu-images', True)
+                                    GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
+                                    GLib.idle_add(submenu_tones[tone_group].append, items[sorted_data[key]["unicode"]])
+                                    GLib.idle_add(items[sorted_data[key]["unicode"]].show)
+                                    signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[key])
+                                else:
+                                    # Show only one tone for toned emojis
+                                    if settings["toned"] == 0 or settings["lowend"] == True:
+                                        # Untoned emojis are already shown by default, so do nothing
+                                        # When using lowend mode, untoned emojis are enforced
+                                        pass
+                                    else:
+                                        desired_tone = settings["toned"]
+                                        current_tone = re.search("\d",sorted_data[key]["name"]).group(0)
+                                        if desired_tone == int(current_tone):
+                                            # Replace item with desired tone
+                                            toned_key = key
+                                            chars = sorted_data[key]["unicode"].split("-") # FIXME this can be multibyte so taking the first byt isn't right
+                                            untoned_code = chars[0]
+                                            for k in sorted_data:
+                                                if sorted_data[k]["unicode"] == untoned_code:
+                                                    key = k
+                                            # Replace image in item
+                                            pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[toned_key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
+                                            img = Gtk.Image.new_from_pixbuf(pixbuf)
+                                            GLib.idle_add(items[sorted_data[key]["unicode"]].set_image, img)
+                                            # Replace action
+                                            items[sorted_data[key]["unicode"]].disconnect(signals[key])
+                                            signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[toned_key])
+                                    
+        # Load icons into recent category
+        recent_items = []
+        for i in range (0, settings["recent"]):
+            recent_items.append( Gtk.ImageMenuItem())
+            item_settings = recent_items[i].get_settings()
+            item_settings.set_property('gtk-menu-images', True)
+            category_menu["recent"].append(recent_items[i])
+        refresh_recent_submenu()
 
-    # Append categories to main menu
-    for category in categories:
-        GLib.idle_add(menu.append, category_item[category])
-        GLib.idle_add(category_item[category].show)
+        # Append categories to main menu
+        for category in categories:
+            GLib.idle_add(menu.append, category_item[category])
+            GLib.idle_add(category_item[category].show)
 
-    # Create separator
-    separator = Gtk.SeparatorMenuItem()
-    GLib.idle_add(menu.append,separator)
-    GLib.idle_add(separator.show)
+        # Create separator
+        separator = Gtk.SeparatorMenuItem()
+        GLib.idle_add(menu.append,separator)
+        GLib.idle_add(separator.show)
 
-    # Create search item
-    search_item = Gtk.MenuItem("Search Emoji")
-    GLib.idle_add(menu.append,search_item)
-    GLib.idle_add(search_item.show)
-    search_item.connect("activate", open_search_window, "Search")
+        # Create search item
+        search_item = Gtk.MenuItem("Search Emoji")
+        GLib.idle_add(menu.append,search_item)
+        GLib.idle_add(search_item.show)
+        search_item.connect("activate", open_search_window, "Search")
 
-    # Create settings item
-    settings_item = Gtk.MenuItem("Settings...")
-    GLib.idle_add(menu.append,settings_item)
-    GLib.idle_add(settings_item.show)    
-    settings_item.connect("activate", open_settings_window, "Settings")
-    
-    # Create another separator
-    separator = Gtk.SeparatorMenuItem()
-    GLib.idle_add(menu.append,separator)
-    GLib.idle_add(separator.show)
+        # Create settings item
+        settings_item = Gtk.MenuItem("Settings...")
+        GLib.idle_add(menu.append,settings_item)
+        GLib.idle_add(settings_item.show)    
+        settings_item.connect("activate", open_settings_window, "Settings")
+        
+        # Create another separator
+        separator = Gtk.SeparatorMenuItem()
+        GLib.idle_add(menu.append,separator)
+        GLib.idle_add(separator.show)
 
-    # Create exit item
-    exit_item = Gtk.MenuItem("Exit")
-    GLib.idle_add(menu.append,exit_item)
-    GLib.idle_add(exit_item.show)
-    exit_item.connect("activate", exit, "Exit")
+        # Create exit item
+        exit_item = Gtk.MenuItem("Exit")
+        GLib.idle_add(menu.append,exit_item)
+        GLib.idle_add(exit_item.show)
+        exit_item.connect("activate", exit, "Exit")
 
-    # Associate menu with indicator
-    ind.set_menu(menu)
+        # Associate menu with indicator
+        ind.set_menu(menu)
 
-    # Gtk main - call after first update
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-    Gtk.main()
+        # Listen to socket
+        try:
+            os.unlink(sockname)
+        except OSError:
+            pass
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.bind(sockname)
+            sock.listen(1)
+            GLib.io_add_watch(sock, GLib.IO_IN, handle_sock_signal)
+        except:
+            print 'Could not listen to socket!'
 
+        # Run server
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        Gtk.main()


### PR DESCRIPTION
Creates a socket the first time emojione-picker is started.
When you try to start again, the search window is showed instead.

Bind any hotkey you want via unity settings, gnome hotkey settings, etc. to emojione-picker, to show the search window on hotkey press.