### PR TITLE
Search: focus input field on new search

### DIFF
--- a/assets/chooser.glade
+++ b/assets/chooser.glade
@@ -21,6 +21,7 @@
     <property name="skip_taskbar_hint">True</property>
     <property name="urgency_hint">True</property>
     <property name="decorated">False</property>
+    <signal name="focus-in-event" handler="onInFocus" swapped="no"/>
     <signal name="focus-out-event" handler="onOutFocus" swapped="no"/>
     <signal name="key-release-event" handler="onKeyReleased" swapped="no"/>
     <child>

--- a/emojione-picker
+++ b/emojione-picker
@@ -194,6 +194,8 @@ class SearchHandler:
         elif event.keyval == Gdk.KEY_Up and selectionChanged == False:
             searchbuilder.get_object("search").grab_focus()
         selectionChanged = False
+    def onInFocus(self, window, data):
+        searchbuilder.get_object("search").grab_focus()
     def onOutFocus(self, window, data):
         window.hide()
 

--- a/emojione-picker
+++ b/emojione-picker
@@ -43,6 +43,8 @@ default_settings = settings = {
     "recent": 20,
     "paste": False
 }
+SIZE=32
+
 configpath = expanduser("~") + "/.config/emojione-picker"
 os.path.isdir(configpath) or os.mkdir(configpath)
 
@@ -131,7 +133,7 @@ def open_search_window(self, w):
         global sorted_recent, searchresults
         for i in sorted_recent:
             emoji_name = sorted_recent[i]["name"]
-            emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[i]["unicode"] + ".svg", 24, 24)
+            emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[i]["unicode"] + ".svg", SIZE, SIZE)
             emoji_code = sorted_recent[i]["unicode"]
             iconstore.append([emoji_image, emoji_code, emoji_name])
             searchresults = []
@@ -153,7 +155,7 @@ class SearchHandler:
             global sorted_recent
             for i in sorted_recent:
                 emoji_name = sorted_recent[i]["name"]
-                emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[i]["unicode"] + ".svg", 24, 24)
+                emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[i]["unicode"] + ".svg", SIZE, SIZE)
                 emoji_code = sorted_recent[i]["unicode"]
                 iconstore.append([emoji_image, emoji_code, emoji_name])
             searchresults = []
@@ -175,7 +177,7 @@ class SearchHandler:
                     return
                 searchresults.append(sorted_data[i])
                 emoji_name = sorted_data[i]["name"]
-                emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[i]["unicode"] + ".svg", 24, 24)
+                emoji_image = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[i]["unicode"] + ".svg", SIZE, SIZE)
                 emoji_code = sorted_data[i]["unicode"]
                 iconstore.append([emoji_image, emoji_code, emoji_name])
     def onIconActivated(self, icon, index):
@@ -253,7 +255,7 @@ def refresh_recent_submenu():
     for key in sorted_recent:
         if i >= settings["recent"]:
             break
-        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
+        pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_recent[key]["unicode"] + ".svg", 96, 96)
         img = Gtk.Image.new_from_pixbuf(pixbuf)
         recent_items[i].set_image(img)
         recent_items[i].set_label(sorted_recent[key]["name"].title())
@@ -369,8 +371,8 @@ if __name__ == "__main__":
           pass
 
         # Get proper icon sizes
-        iconsizes = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
-
+        iconsizes = [None, SIZE, SIZE]
+        
         # Create categories items and submenus
         category_item = {}
         category_menu = {}

--- a/emojione-picker
+++ b/emojione-picker
@@ -36,7 +36,7 @@ for d in directories:
 categories = ["recent", "people", "food", "nature", "objects", "activity", "travel", "flags", "symbols"]
 
 # Settings handling
-default_settings = settings = { 
+default_settings = settings = {
     "toned": -1,
     "notifications": True,
     "lowend": False,
@@ -87,7 +87,7 @@ class SettingsButtonHandler:
 def apply_settings():
     global settings
     # Get settings from dialog
-    settings = { 
+    settings = {
         "toned": builder.get_object("combo_toned").get_active()-1,
         "notifications": builder.get_object("check_notifications").get_active(),
         "lowend": builder.get_object("check_lowend").get_active(),
@@ -205,14 +205,14 @@ if os.path.isfile(configfile):
           settings = json.load(settings_json_file)
       except:
           save_settings()
-      
+
 else:
     save_settings()
 
 for k in default_settings.keys():
     if not k in settings:
         settings[k] = default_settings[k]
-  
+
 # Load recent emojis at startup
 recentfile = configpath + "/recent.json"
 if os.path.isfile(recentfile):
@@ -331,7 +331,7 @@ def item_response(self, w):
         json.dump(recent, outfile)
 
     # Refresh recent icons submenu
-    GLib.idle_add(refresh_recent_submenu)  
+    GLib.idle_add(refresh_recent_submenu)
 
 def get_emoji_group(code):
     for key in groups_data:
@@ -368,7 +368,7 @@ if __name__ == "__main__":
 
         # Get proper icon sizes
         iconsizes = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
-        
+
         # Create categories items and submenus
         category_item = {}
         category_menu = {}
@@ -435,7 +435,7 @@ if __name__ == "__main__":
                                 # This won't happen, we are not grouping toned icons
                                 pass
                         else:
-                            if tones_re.match(sorted_data[key]["name"]) == None: 
+                            if tones_re.match(sorted_data[key]["name"]) == None:
                                 # Not toned emoji (aka simplest case), just add to menu
                                 pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(directory + "/assets/svg/" + sorted_data[key]["unicode"] + ".svg", iconsizes[1], iconsizes[2])
                                 img = Gtk.Image.new_from_pixbuf(pixbuf)
@@ -507,7 +507,7 @@ if __name__ == "__main__":
                                             # Replace action
                                             items[sorted_data[key]["unicode"]].disconnect(signals[key])
                                             signals[key] = items[sorted_data[key]["unicode"]].connect("activate", item_response, sorted_data[toned_key])
-                                    
+
         # Load icons into recent category
         recent_items = []
         for i in range (0, settings["recent"]):
@@ -536,9 +536,9 @@ if __name__ == "__main__":
         # Create settings item
         settings_item = Gtk.MenuItem("Settings...")
         GLib.idle_add(menu.append,settings_item)
-        GLib.idle_add(settings_item.show)    
+        GLib.idle_add(settings_item.show)
         settings_item.connect("activate", open_settings_window, "Settings")
-        
+
         # Create another separator
         separator = Gtk.SeparatorMenuItem()
         GLib.idle_add(menu.append,separator)
@@ -552,6 +552,9 @@ if __name__ == "__main__":
 
         # Associate menu with indicator
         ind.set_menu(menu)
+
+        # Enable middle-button mouse click to open search window
+        ind.set_secondary_activate_target(search_item)
 
         # Listen to socket
         try:


### PR DESCRIPTION
When re-entering the search box, the focus is on the last selected Emoji. Typically, if you are looking for a search, you want to type a new alias string.

This patch will always focus the input field when opening the search box, and that will auto-mark the current text, so you can just start typing away.