### PR TITLE
Fix searchbar focus

### DIFF
--- a/emojione-picker
+++ b/emojione-picker
@@ -113,18 +113,28 @@ def open_search_window(self, w):
     global search_window
     # Build window only once
     try:
+        search_window.set_keep_above(True)
         search_window.show_all()
         search_window.present()
         search_window.grab_focus()
+	
+        # Without this, the subsequent click won't work. Replacing this with a sleep does not work. It's magic!
+        search_window.get_position()
+        os.system("xdotool click 1")
     except:
         # Build window
         searchbuilder = Gtk.Builder()
         searchbuilder.add_from_file(directory + "/assets/chooser.glade")
         searchbuilder.connect_signals(SearchHandler())
         search_window = searchbuilder.get_object("search_window")
+        search_window.set_keep_above(True)
         search_window.show_all()
         search_window.present()
         search_window.grab_focus()
+	
+        # Without this, the subsequent click won't work. Replacing this with a sleep does not work. It's magic!
+        search_window.get_position()
+        os.system("xdotool click 1")
 
         # Put recent icons by default
         iconstore = searchbuilder.get_object("iconstore")


### PR DESCRIPTION
Fixes https://github.com/gentakojima/emojione-picker-ubuntu/issues/18

`set_keep_above` raises the window to the front but doesn't focus it yet
Since the window gets created at the location of the mouse, `xdotool click` should now focus it.
For some reason, the window only actually gets focus when calling `get_position` first. This does not seem to be a timing issue as replacing `get_position` with a `sleep` does not work.